### PR TITLE
Simplify config after Community Bridge integration

### DIFF
--- a/config/config.lua
+++ b/config/config.lua
@@ -2,17 +2,18 @@ Config = {}
 
 Config.Debug = true
 
-Config.Framework = 'auto'          -- auto, qbx , qb, esx,
-Config.Inventory = 'qb'            -- ox , qb, esx, ps, qs
+-- Community Bridge automatically detects frameworks, notifications and
+-- inventories. Only configure target options below if you need to
+-- override the default behaviour.
 
 Config.UseTarget = true           -- setting to false will use interact instead of target
-Config.Target = 'qb'              -- ox , qb
 
-Config.Notification = 'qb'         -- ox , qb, esx, k5, okok, xs
-Config.XSNotifyLocation = 0              -- 0 Middle, 1 Bottom, 2 Left, 3 Right. THIS ONLY MATTERS IF Config.Notification = 'xs'
-
-Config.Progress = 'ox-circle'      -- ox-normal , ox-circle , qb, esx
-Config.OxCirclePosition = 'bottom' -- only matters if Config.Progress = 'ox-circle'
+-- When UseTarget is disabled force the Community Bridge to use the
+-- sleepless_interact module rather than a traditional target system.
+if not Config.UseTarget then
+    BridgeClientConfig = BridgeClientConfig or {}
+    BridgeClientConfig.TargetSystem = 'sleepless_interact'
+end
 
 Config.RecycleCenter = {
     Enter = vec4(-572.05, -1631.29, 19.41, 181.47),

--- a/shared/shared.lua
+++ b/shared/shared.lua
@@ -17,28 +17,12 @@ function DebugPrint(...)
 end
 
 function DetectCore()
-    if Config.Framework == 'auto' then
-        if GetResourceState('qbx_core') == 'started' then
-            Config.Framework = 'qbx'
-        elseif GetResourceState('qb-core') == 'started' then
-            Config.Framework = 'qb'
-        elseif GetResourceState('es_extended') == 'started' then
-            Config.Framework = 'esx'
-        else
-            Config.Framework = 'none'
-        end
-    end
-
-    DebugPrint('Cornerstone Recyling Started with for the : ' .. Config.Framework .. ' framework')
-    DebugPrint('++ Notifications: ' .. Config.Notification)
-    DebugPrint('++ Inventory: ' .. Config.Inventory)
+    DebugPrint('Cornerstone Recycling using Community Bridge auto-detection')
     if Config.UseTarget then
-        DebugPrint('++ Target: ' .. Config.Target)
+        DebugPrint('++ Using target interactions')
     else
-        DebugPrint('++ Target is Disabled')
+        DebugPrint('++ Using interact interactions')
     end
-   
-    DebugPrint('++ Progress: ' .. Config.Progress)
 end
 
 AddEventHandler('onResourceStart', function(resource)


### PR DESCRIPTION
## Summary
- remove redundant framework/inventory/notification configs
- trim debug logging to show only target info
- support interact when `UseTarget` is false via Community Bridge
- switch client code to Community Bridge's target API

## Testing
- `luac -p config/config.lua`
- `luac -p shared/shared.lua`


------
https://chatgpt.com/codex/tasks/task_e_6855afc62a548330b62b84385506d783